### PR TITLE
Fix Vigilante Failed to Respond after Using One-Time Action

### DIFF
--- a/classes/roles/vigilante.py
+++ b/classes/roles/vigilante.py
@@ -10,6 +10,8 @@ class Vigilante(KillRole):
 	async def handle_button_click(self, game, player, interaction, action_view=None):
 		if not self.can_act(player):
 			await interaction.response.send_message("You have already used your shot!", ephemeral=True)
+			if action_view:
+				action_view.pending_humans.discard(interaction.user.id)
 			return
 		await super().handle_button_click(game, player, interaction, action_view)
 

--- a/classes/views.py
+++ b/classes/views.py
@@ -536,7 +536,7 @@ class SpecialActionsView(discord.ui.View):
 				self.add_item(SpecialActionButton(player.role))
 				added_roles.add(player.role.name)
 
-		self.pending_humans = {p.user.id for p in alive_players if p.role.is_special() and isinstance(p.user, discord.Member)}
+		self.pending_humans = {p.user.id for p in alive_players if p.role.is_special() and isinstance(p.user, discord.Member) and p.role.can_act(p)}
 
 	def get(self, id):
 		return discord.utils.get(self.children, custom_id=id)


### PR DESCRIPTION
Vigilantes who already used their single bullet were still added to `pending_humans` each night, causing them to accumulate inactivity failures and eventually get modkilled despite having no available action.

- **`classes/views.py`**: Gate `pending_humans` membership on `can_act(player)` so spent one-shot roles are never awaited
- **`classes/roles/vigilante.py`**: Defensively discard from `pending_humans` if a spent vigilante clicks the button anyway

```python
# Before — all special-role humans tracked regardless of ability to act
self.pending_humans = {p.user.id for p in alive_players if p.role.is_special() and isinstance(p.user, discord.Member)}

# After — only players who can actually act are tracked
self.pending_humans = {p.user.id for p in alive_players if p.role.is_special() and isinstance(p.user, discord.Member) and p.role.can_act(p)}
```